### PR TITLE
Avoid throwing an error with Python3

### DIFF
--- a/forbiddenpass.py
+++ b/forbiddenpass.py
@@ -116,10 +116,11 @@ def main():
                 links = args.target + bypass
                 do_request(links)
 
-processes = []
-for _ in range(1):
-    process = multiprocessing.Process(target=main)
-    process.start()
-    processes.append(process)
-for process in processes:
-    process.join()
+if __name__ == '__main__':
+	processes = []
+	for _ in range(1):
+	 process = multiprocessing.Process(target=main)
+	 process.start()
+	 processes.append(process)
+	for process in processes:
+	 process.join()


### PR DESCRIPTION
Getting an error without that:

  ```
RuntimeError:
          An attempt has been made to start a new process before the
          current process has finished its bootstrapping phase.
  
          This probably means that you are not using fork to start your
          child processes and you have forgotten to use the proper idiom
          in the main module:
  
              if __name__ == '__main__':
                  freeze_support()
                  ...
  
          The "freeze_support()" line can be omitted if the program
          is not going to be frozen to produce an executable.

```